### PR TITLE
Handle string indexes

### DIFF
--- a/lib/schema_plus/columns/active_record/connection_adapters/column.rb
+++ b/lib/schema_plus/columns/active_record/connection_adapters/column.rb
@@ -13,7 +13,9 @@ module SchemaPlus::Columns
         # refers to this column.  Returns an empty list if there are no
         # such indexes.
         def indexes
-          @indexes ||= @model.indexes.select{|index| index.columns.include? self.name}
+          @indexes ||= @model.indexes.select{|index| index.columns.include? self.name}.each do |index|
+            index.instance_variable_set(:@columns, index.columns.is_a?(Array) ? index.columns : [index.columns])
+          end
         end
 
         # If the column is in a unique index, returns a list of names of other columns in

--- a/spec/column_spec.rb
+++ b/spec/column_spec.rb
@@ -89,6 +89,22 @@ describe "Column" do
       end
     end
 
+    context "if string index" do
+      before(:each) do
+        create_table(User, :login => { :index => {}})
+        add_index(User, 'lower(login)', name: 'index_users_on_lower_login', unique: true)
+        @login = User.columns.find{|column| column.name == "login"}
+      end
+
+      it "should report unique" do
+        expect(@login).to be_unique
+      end
+
+      it "should report an empty unique scope" do
+        expect(@login.unique_scope).to eq([])
+      end
+    end
+
     context "with case insensitive" do
       before(:each) do
         create_table(User, :login => { :index => {}})
@@ -157,6 +173,15 @@ describe "Column" do
         end
       end
       model.reset_column_information
+    end
+  end
+
+  def add_index(model, index, options = {})
+    migration.suppress_messages do
+      unless migration.index_exists?(model.table_name, name: index)
+        migration.add_index model.table_name, index, options
+        model.reset_column_information
+      end
     end
   end
 


### PR DESCRIPTION
In rails > 5.2 if we add indexes like mentioned [here](https://github.com/SchemaPlus/schema_plus_pg_indexes) e.g.:
```ruby
add_index :users, 'lower(name)', name: 'index_users_on_name', unique: true
```
then rails will generate a line in schema.rb like so:
```ruby
t.index "lower((name)::text)", name: "index_users_on_name", unique: true
```
which for example breaks the `unique_scope` method or the `has_case_insensitive_index?` method in `schema_validations` cause strings do not implement `reject` or `map` methods.

This PR add a workaround for that together with some tests - it's ugly, but that's the only thing that worked for me, as I just tried to use `schema_validations`.

Although I will admit that after spending 2 hours on trying to configure `schema_dev` I gave up, so I'm going to use your CI and hope it will not fail :sweat_smile: 